### PR TITLE
Use newer ArrayBuffer interface for node > 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: Libsys linux CI
+on: [push]
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 21.5.0
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - run: cd ${{ github.workspace }}
+      - run: npm i
+      - run: npm test

--- a/libsys.cc
+++ b/libsys.cc
@@ -50,14 +50,14 @@ namespace libsys {
 
     inline uint64_t GetAddrArrayBuffer(Local<Object> obj) {
         Local<ArrayBuffer> ab = obj.As<ArrayBuffer>();
-        ArrayBuffer::Contents ab_c = ab->GetContents();
-        return (uint64_t)(ab_c.Data());
+        std::shared_ptr<v8::BackingStore> ab_c = ab->GetBackingStore();
+        return (uint64_t)(ab_c->Data());
     }
 
     inline uint64_t GetAddrTypedArray(Local<Object> obj) {
         Local<TypedArray> ta = obj.As<TypedArray>();
-        ArrayBuffer::Contents ab_c = ta->Buffer()->GetContents();
-        return (uint64_t)(ab_c.Data()) + ta->ByteOffset();
+        std::shared_ptr<v8::BackingStore> ab_c = ta->Buffer()->GetBackingStore();
+        return (uint64_t)(ab_c->Data()) + ta->ByteOffset();
     }
 
     inline uint64_t GetAddrUint8Array(Local<Object> obj) {
@@ -328,7 +328,10 @@ namespace libsys {
         void* addr = (void*) ArgToInt(args[0]);
         size_t size = (size_t) Nan::To<int32_t>(args[1]).FromJust();
 
-        Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, addr, size);
+        std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore(
+                addr, size, [](void*, size_t, void*){}, nullptr);
+
+        Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, std::move(backing));
         args.GetReturnValue().Set(buf);
     }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "./build/Release/sys.node",
   "engines": {
-    "node": ">= 4.4.3"
+    "node": ">= 17.0.0"
   },
   "gypfile": true,
   "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/streamich/libsys/issues/553

v8 deprecated `ArrayBuffer::GetContents` in [here](https://github.com/v8/v8/commit/bfe3d6bce734e596e312465e207bcfd55a59fe34)

and removed the interface [here](https://github.com/v8/v8/commit/578f6be77fc5d8af975005c2baf918e7225abb62) in [9.1.117](https://github.com/v8/v8/releases/tag/9.1.117)

[Here](https://docs.google.com/document/d/1sTc_jRL87Fu175Holm5SV0kajkseGl2r8ifGY76G35k/edit#heading=h.5irk4csrpu0y) is the upgrade guide.

Node seems to have moved to the breaking v8 version between 16.3 and 16.4:

```bash
/tmp $ fnm use 16.3
Using Node v16.3.0
/tmp $ node --version
v16.3.0
/tmp $ node -p process.versions.v8
9.0.257.25-node.16
/tmp $ fnm use 16.4
Using Node v16.4.0
/tmp $ node --version
v16.4.0
/tmp $ node -p process.versions.v8
9.1.269.36-node.14
/tmp $
```
This would be a major version bump if released.

I added the CI because I couldn't run the build and test [locally on my M3](https://github.com/streamich/libsys/issues/430), or in the provided Docker image either (it is trying to call into the host on compiling, I believe, sorry don't know Docker internals in detail.) 
